### PR TITLE
Issue #18 fixes

### DIFF
--- a/components/desktop-navbar.js
+++ b/components/desktop-navbar.js
@@ -31,6 +31,16 @@ template.innerHTML = `
     </div>
     <div class="cards" id="cards"></div>
 `;
+
+
+const backgroundColors = {
+  "SSDLC Requirements": "rgba(26, 191, 161, 0.7)",
+  "SSDLC Design": "rgba(56, 141, 205, 0.75)",
+  "SSDLC Testing": "rgba(225, 67, 152, 0.75)",
+  "SSDLC Development": "rgba(236, 165, 75, 0.75)",
+  "SSDLC Deployment": "rgba(239, 115, 63, 0.75)"
+};
+
 export default class DesktopComponent extends HTMLElement {
   constructor() {
     super();
@@ -72,6 +82,13 @@ export default class DesktopComponent extends HTMLElement {
       const tab = document.createElement("li");
       tab.classList.add("tab");
       tab.textContent = item.naam;
+
+
+      const backgroundColor = backgroundColors[item.naam];
+      if (backgroundColor) {
+          tab.style.backgroundColor = backgroundColor;
+      }
+      
       tabsContainer.appendChild(tab);
 
       const dropdown = document.createElement("ul");
@@ -89,10 +106,18 @@ export default class DesktopComponent extends HTMLElement {
   }
 
   showTree(item, label, event) {
+    
     const ssdlcFaseElement = this.shadowRoot.querySelector(".ssdlc-fase");
     const hboIActiviteitElement =
       this.shadowRoot.querySelector(".hbo-i-activiteit");
+    const contenttop = this.shadowRoot.querySelector(".content-top");
     ssdlcFaseElement.textContent = item.naam;
+
+    const backgroundColor = backgroundColors[item.naam];
+    if (backgroundColor) {
+        contenttop.style.backgroundColor = backgroundColor;
+    }
+
     hboIActiviteitElement.textContent = label.naam;
 
     const vaardigheden = label.vaardigheden || [];
@@ -136,6 +161,7 @@ export default class DesktopComponent extends HTMLElement {
         subtree.style.display = "none";
 
         this.buildTree(item.vaardigheden, subtree, true);
+        this.toggleSubtree(li);
       } else {
         const childIcon = document.createElement("span");
         childIcon.textContent = "◆";

--- a/css/desktop-navbar.css
+++ b/css/desktop-navbar.css
@@ -27,7 +27,6 @@
 
 .content-top {
   height: 8%;
-
   border: 1px solid;
   padding: 10px;
   display: flex;
@@ -111,7 +110,10 @@ option {
   cursor: pointer;
   border-bottom: 2px solid transparent;
   position: relative;
-  font-size: 1.4rem !important;
+  font-size: 1.2rem !important;
+  border-radius: 10px;
+  margin-left: 5px;
+  margin-right: 5px;
 }
 
 .tab.active {

--- a/css/style.css
+++ b/css/style.css
@@ -8,7 +8,7 @@
   --secondary-color: #f7cd46;
   --secondary-color-dark: #f5a61a;
   --background-color: #fdbd77;
-  --background-color-light: peachpuff;
+  --background-color-light: #F6F7F8;
   --background-color-dark: orange;
 }
 html,


### PR DESCRIPTION
- Relevante kleurkoppeling toegevoegd voor alle ssldc-items (zowel als in menu als in de boom) 
- Curriculum standaard uitgeklapt weergeven

Todo; het curriculum als boom/voetbaltoernooi schema weergeven.